### PR TITLE
cargo: use upstream gettext-macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 [[package]]
 name = "gettext-macros"
 version = "0.6.0"
-source = "git+https://github.com/Valodim/gettext-macros?rev=d15fa92ef6ac28269890557fe9c3767d01442633#d15fa92ef6ac28269890557fe9c3767d01442633"
+source = "git+https://github.com/Plume-org/gettext-macros?rev=2227905fb949ee107053eeda982530407e51ae99#2227905fb949ee107053eeda982530407e51ae99"
 dependencies = [
  "gettext",
  "gettext-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ default-features = false
 features = ["rocket"]
 
 [patch.crates-io]
-gettext-macros = { git = "https://github.com/Valodim/gettext-macros", rev = "d15fa92ef6ac28269890557fe9c3767d01442633" }
+gettext-macros = { git = "https://github.com/Plume-org/gettext-macros", rev = "2227905fb949ee107053eeda982530407e51ae99" }
 
 [dependencies.lettre]
 version = "0.10.0-pre"


### PR DESCRIPTION
Upstream merged the patch we introduced in 9d5ec287a996b7276b724e53a0567c5212be4a08, so we can use that version while we wait for a release.